### PR TITLE
Fixed AVR include

### DIFF
--- a/mLink.h
+++ b/mLink.h
@@ -50,8 +50,6 @@ Please see Licence.txt in the library folder for terms of use.
 #define MLINK_h
 
 #ifdef __AVR__
-//Do nothing
-#else
 #include <avr/dtostrf.h>
 #endif
 


### PR DESCRIPTION
Without this fix compilation failed for non-AVR MCUs.